### PR TITLE
Update Mac instructions for OAuth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ Now we need to set up the Learn gem. Type the following into your terminal:
 learn whoami
 ```
 
-This will prompt you to set up the Learn gem  using a token provided on `learn.co`.
-The gem should ask you to go to `learn.co/your-github-username`. Paste this URL
-in a new browser tab and replace `your-github-username` with your personal GitHub
-username. At the bottom of the page is the token you'll need.
+This will prompt you to set up the Learn gem using a token provided on `learn.co`.
+
+- If you have connected your Github account to your Learn account, navigate to learn.co/your_github_username. The OAuth token is at the bottom of the page.
+- If you have not connected your Github account: Go to [your profile](https://learn.co/account/profile) > Learn Settings > Public Profile. Click on the link under **Username**. The OAuth token is at the bottom of the page.
 
 **Note:** At the end of this lesson is additional troubleshooting information. If you
 receive an error when running `learn whoami`, please try the steps listed there.


### PR DESCRIPTION
We're currently running a course with learn.co and a number of students have been tripped over this step because it presumes that a Github is connected to the Learn account, but that's not necessarily the case.

Also see:
* https://github.com/learn-co-curriculum/linux-env-setup/pull/12
* https://github.com/learn-co-curriculum/wsl-setup/pull/7